### PR TITLE
Fix autocomplete with OPAM modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,26 @@
 
     opam install ocp-index
 
-## Configuration
+## OPAM Configuration
+
+This plugin uses `ocp-index -I <folder>` to enable searching local project libraries. If instead you are using libraries in OPAM, the use of `-I` disables the default ocp-index behaviour to search for and use the OPAM main directory. To switch to showing OPAM libraries in autocomplete results, add the following to your sublime preferences:
+
+    "autocomplete-local-ocaml-packages": false
+
+## Build configuration
 
 You need to pass the `-bin-annot` flag to ocamlc/ocamlopt. You are probably using a build system, so follow the guide below.
 
 ### ocamlbuild
 
-Ocamlbuild currently does not support generating binary annotations out of the box, but this can be solved by adding one line to `myocamlbuild.ml`:
+Ocamlbuild 4.01 supports generating binary annotations out of the box, with the bin_annot tag. In your `_tags`:
+
+    true: bin_annot
+
+For earlier versions of Ocamlbuild, this can be replicated by adding one line to `myocamlbuild.ml`:
 
     flag ["ocaml"; "compile"; "bin_annot"] (A"-bin-annot");
 
-and `_tags`:
-
-    true: bin_annot
 
 ## License
 

--- a/sublime_ocp_index.py
+++ b/sublime_ocp_index.py
@@ -43,7 +43,7 @@ class SublimeOCPIndex(sublime_plugin.EventListener):
             return
 
         line = view.substr(sublime.Region(view.line(locations[0]).begin(), locations[0]))
-        match = re.search(r"[,\s]*([A-Z][\w_.']*|[\w_]+)$", line)
+        match = re.search(r"[,\s]*([A-Z][\w_.#']*|[\w_]+)$", line)
 
         if match != None:
             (context,) = match.groups()

--- a/sublime_ocp_index.py
+++ b/sublime_ocp_index.py
@@ -3,6 +3,31 @@ import sublime
 import subprocess
 import re
 
+DEFAULT_INCLUDE = True
+
+localInclude = DEFAULT_INCLUDE
+
+def plugin_loaded():
+    s = sublime.load_settings('Preferences.sublime-settings')
+
+    def read_pref():
+        include = s.get('autocomplete-local-ocaml-packages')
+        global localInclude
+        if include is not None:
+            localInclude = include
+        else:
+            localInclude = DEFAULT_INCLUDE
+
+    # read initial setting
+    read_pref()
+    # listen for changes
+    s.clear_on_change("OCaml Autocompletion")
+    s.add_on_change("OCaml Autocompletion", read_pref)
+
+# ST2 backwards compatibility
+if (int(sublime.version()) < 3000):
+    plugin_loaded()
+
 class SublimeOCPIndex(sublime_plugin.EventListener):
 
     local_cache = dict()
@@ -66,9 +91,10 @@ class SublimeOCPIndex(sublime_plugin.EventListener):
     def run_completion(self, includes, opens, query, length):
         args = ['ocp-index', 'complete']
 
-        for include in includes:
-            args.append('-I')
-            args.append(include)
+        if localInclude:
+            for include in includes:
+                args.append('-I')
+                args.append(include)
 
         for open in opens:
             args.append('-O')


### PR DESCRIPTION
While the documentation for `ocp-index -I` doesn't make it particularly clear, the default behaviour (locate the OPAM folder and search OPAM packages for autocompletion) is disabled when you use it. I figured you had a reason for making use of it, so I've left that as the default and added an option to disable searching local libraries.

A couple of bonus changes:
- I added a `#` to the line regex to include object method calls in autocompletion.
- ocamlbuild appears to support the `bin_annot` tag out of the box now, using your fix actually passes it twice to ocamlc. I have no idea if this is new in 4.01 but I assume it is. Updated the readme.
