### PR TITLE
Display the type at the cursor with alt+a

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,0 +1,5 @@
+[
+	{
+		"keys":["alt+a"],"command":"sublime_ocp_types"
+	}
+]

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ There are limitations to this approach, and some scenarios such as inside `let o
 
 ## OPAM Configuration
 
-This plugin uses `ocp-index -I <folder>` to enable searching local project libraries. If instead you are using libraries in OPAM, the use of `-I` disables the default ocp-index behaviour to search for and use the OPAM main directory. To switch to showing OPAM libraries in autocomplete results, use the following setting:
+This plugin uses `ocp-index -I <folder>` to enable searching local project libraries. If instead you are using libraries in OPAM, the use of `-I` disables the default ocp-index behaviour of searching for and use the OPAM main directory. To switch to showing OPAM libraries in autocomplete results, use the following setting:
 
-    "autocomplete-local-ocaml-packages": false
+    "sublime_ocp_index_include_local_packages": false
 
 This can be applied globally in your user settings, or overridden in a `.sublime-project` file.
 
@@ -25,9 +25,9 @@ This can be applied globally in your user settings, or overridden in a `.sublime
 
 You need to pass the `-bin-annot` flag to ocamlc/ocamlopt. You are probably using a build system, so follow the guide below.
 
-If you are not using one of the [standard build output folders](https://github.com/OCamlPro/ocp-index/blob/81ad7ac148bab1188bcf401f8cdd3859730f5aa8/src/indexMisc.ml#L102) then the setting `ocamlbuild_dir` can be used to passed the `--build` parameter to `ocp-index`:
+If you are not using one of the [standard build output folders](https://github.com/OCamlPro/ocp-index/blob/81ad7ac148bab1188bcf401f8cdd3859730f5aa8/src/indexMisc.ml#L102) then this setting can be used to passed the `--build` parameter to `ocp-index`:
 
-    "ocamlbuild_dir": "gen/ml"
+    "sublime_ocp_index_build_dir": "gen/ml"
 
 This setting can be applied as a user preference or (recommended) in your `.sublime-project` file.
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
 Within OCaml syntax files:
 
 - Standard sublime autocompletion is completely replaced with OCaml autocompletion
-- Type checking of variables is available via the `alt+a` shortcut, which displays the type in the status bar
-
-There are limitations to this approach, and some scenarios such as inside `let open <module> in` will not find any results.
+- Type inspection of variables is available via the `alt+a` shortcut, which displays the type in the status bar
 
 ## OPAM Configuration
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This plugin uses `ocp-index -I <folder>` to enable searching local project libra
 
     "autocomplete-local-ocaml-packages": false
 
+This can be applied in your user settings, and overridden in a `.sublime-project` file.
+
 ## Build configuration
 
 You need to pass the `-bin-annot` flag to ocamlc/ocamlopt. You are probably using a build system, so follow the guide below.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@ This plugin uses `ocp-index -I <folder>` to enable searching local project libra
 
     "autocomplete-local-ocaml-packages": false
 
-This can be applied in your user settings, and overridden in a `.sublime-project` file.
+This can be applied globally in your user settings, or overridden in a `.sublime-project` file.
 
 ## Build configuration
 
 You need to pass the `-bin-annot` flag to ocamlc/ocamlopt. You are probably using a build system, so follow the guide below.
 
-If you are not using one of the standard build output folders (e.g. `_build` for ocamlbuild) then the setting `ocamlbuild_dir` will be passed as the `--build` parameter to `ocp-index`. This setting can be applied as a user preference or in your `.sublime-project` file.
+If you are not using one of the [standard build output folders](https://github.com/OCamlPro/ocp-index/blob/81ad7ac148bab1188bcf401f8cdd3859730f5aa8/src/indexMisc.ml#L102) then the setting `ocamlbuild_dir` can be used to passed the `--build` parameter to `ocp-index`:
+
+    "ocamlbuild_dir": "gen/ml"
+
+This setting can be applied as a user preference or (recommended) in your `.sublime-project` file.
 
 ### ocamlbuild
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,26 @@
 
     opam install ocp-index
 
+## Usage
+
+Within OCaml syntax files:
+
+- Standard sublime autocompletion is completely replaced with OCaml autocompletion
+- Type checking of variables is available via the `alt+a` shortcut, which displays the type in the status bar
+
+There are limitations to this approach, and some scenarios such as inside `let open <module> in` will not find any results.
+
 ## OPAM Configuration
 
-This plugin uses `ocp-index -I <folder>` to enable searching local project libraries. If instead you are using libraries in OPAM, the use of `-I` disables the default ocp-index behaviour to search for and use the OPAM main directory. To switch to showing OPAM libraries in autocomplete results, add the following to your sublime preferences:
+This plugin uses `ocp-index -I <folder>` to enable searching local project libraries. If instead you are using libraries in OPAM, the use of `-I` disables the default ocp-index behaviour to search for and use the OPAM main directory. To switch to showing OPAM libraries in autocomplete results, use the following setting:
 
     "autocomplete-local-ocaml-packages": false
 
 ## Build configuration
 
 You need to pass the `-bin-annot` flag to ocamlc/ocamlopt. You are probably using a build system, so follow the guide below.
+
+If you are not using one of the standard build output folders (e.g. `_build` for ocamlbuild) then the setting `ocamlbuild_dir` will be passed as the `--build` parameter to `ocp-index`. This setting can be applied as a user preference or in your `.sublime-project` file.
 
 ### ocamlbuild
 

--- a/sublime_ocp_index.py
+++ b/sublime_ocp_index.py
@@ -3,9 +3,174 @@ import sublime
 import subprocess
 import re
 
+OCPKEY = "OCaml Autocompletion"
 DEFAULT_INCLUDE = True
 
 localInclude = DEFAULT_INCLUDE
+
+
+class SublimeOCPIndex():
+    local_cache = dict()
+
+    def run_ocp(self, command, includes, opens, query, length, buildDir):
+        args = ['ocp-index', command]
+
+        if localInclude:
+            for include in includes:
+                args.append('-I')
+                args.append(include)
+
+        if buildDir is not None:
+            args.append('--build')
+            args.append(buildDir)
+
+        for open in opens:
+            args.append('-O')
+            args.append(open)
+
+        args.append(query)
+
+        print(args)
+
+        proc = subprocess.Popen(args,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE)
+
+        error  = proc.stderr.read().decode('utf-8').strip()
+        output = proc.stdout.read().decode('utf-8').strip()
+
+        if error:
+            return error
+        else:
+            return output
+
+    def extract_query(self, view, location):
+        scopes = set(view.scope_name(location).split(" "))
+
+        if len(set(["source.ocaml", "source.ocamllex", "source.ocamlyacc"]) & scopes) == 0:
+            return None
+
+        line = view.substr(sublime.Region(view.line(location).begin(), location))
+        match = re.search(r"[,\s]*([A-Z][\w_.#']*|[\w_]+)$", line)
+
+        if match != None:
+            (context,) = match.groups()
+            length = 0# len(context) - len(prefix)
+
+            header = view.substr(sublime.Region(0, 4096))
+            opens  = re.findall(r"^open ([\w.]+)$", header, flags=re.MULTILINE)
+
+            if view.file_name() != None:
+                (module,) = re.search(r"(\w+)\.ml.*$", view.file_name()).groups()
+                opens.append(module.capitalize())
+
+
+            buildDir = view.settings().get('ocamlbuild_dir')
+
+            return (opens, context, length, buildDir)
+        else:
+            return None
+
+    def query_type(self, view, location):
+        endword = view.word(location).end()
+        query = self.extract_query(view, endword)
+
+        if query is not None:
+            (opens, context, length, buildDir) = query
+
+            return self.run_ocp('type', view.window().folders(), opens, context, length, buildDir)
+
+    def query_completions(self, view, prefix, location):
+        query = self.extract_query(view, location)
+
+        if query is not None:
+            (opens, context, length, buildDir) = query
+
+            output = self.run_ocp('complete', view.window().folders(), opens, context, length, buildDir)
+
+
+            results = []
+
+            if prefix == "_":
+                results.append(('_', '_'))
+
+            variants = re.sub(r"\n\s+", " ", output).split("\n")
+
+            for variant in variants:
+                if variant.count(" ") > 0:
+                    (replacement, rest) = str.split(variant, " ", 1)
+                    actual_replacement = replacement[length:]
+                    results.append((replacement + "\t" + rest, actual_replacement))
+
+            if view.buffer_id() in self.local_cache:
+                results += self.local_cache[view.buffer_id()]
+
+            return results, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS
+
+    def extract_locals(self, view):
+        local_defs = []
+        view.find_all(r"let(\s+rec)?\s+(([?~]?[\w']+\s*)+)=", 0, r"\2", local_defs)
+        view.find_all(r"fun\s+(([?~]?[\w']+\s*)+)->", 0, r"\1", local_defs)
+
+        locals = set()
+        for definition in local_defs:
+            for local in str.split(definition):
+                (local,) = re.match(r"^[?~]?(.+)", local).groups()
+                locals.add((local + "\tlet", local))
+
+        self.local_cache[view.buffer_id()] = list(locals)
+
+
+
+## Boilerplate and connecting plugin classes to the real logic
+sublimeocp = SublimeOCPIndex()
+
+class SublimeOCPEventListener(sublime_plugin.EventListener):
+
+    def on_query_completions(self, view, prefix, locations):
+        if len(locations) != 1:
+            return
+
+        return sublimeocp.query_completions(view, prefix, locations[0])
+
+    if int(sublime.version()) < 3014:
+        def on_close(self, view):
+            sublimeocp.local_cache.pop(view.buffer_id())
+
+        def on_load(self, view):
+            sublimeocp.extract_locals(view)
+
+        def on_post_save(self, view):
+            sublimeocp.extract_locals(view)
+
+        def on_selection_modified(self, view):
+            view.erase_status(OCPKEY)
+
+    else:
+        def on_close_async(self, view):
+            sublimeocp.local_cache.pop(view.buffer_id())
+
+        def on_load_async(self, view):
+            sublimeocp.extract_locals(view)
+
+        def on_post_save_async(self, view):
+            sublimeocp.extract_locals(view)
+
+        def on_selection_modified_async(self, view):
+            view.erase_status(OCPKEY)
+
+class SublimeOcpTypes(sublime_plugin.TextCommand):
+        def run(self, enable):
+            locations = self.view.sel()
+
+            result = sublimeocp.query_type(self.view, locations[0])
+
+            if (result is None or len(result) == 0):
+                displayType = "Unknown type"
+            else:
+                displayType = result
+
+            self.view.set_status(OCPKEY,"Type: " + displayType)
 
 def plugin_loaded():
     s = sublime.load_settings('Preferences.sublime-settings')
@@ -21,113 +186,9 @@ def plugin_loaded():
     # read initial setting
     read_pref()
     # listen for changes
-    s.clear_on_change("OCaml Autocompletion")
-    s.add_on_change("OCaml Autocompletion", read_pref)
+    s.clear_on_change(OCPKEY)
+    s.add_on_change(OCPKEY, read_pref)
 
 # ST2 backwards compatibility
 if (int(sublime.version()) < 3000):
     plugin_loaded()
-
-class SublimeOCPIndex(sublime_plugin.EventListener):
-
-    local_cache = dict()
-
-    def on_query_completions(self, view, prefix, locations):
-        if len(locations) != 1:
-            return
-
-        (location,) = locations
-        scopes      = set(view.scope_name(location).split(" "))
-
-        if len(set(["source.ocaml", "source.ocamllex", "source.ocamlyacc"]) & scopes) == 0:
-            return
-
-        line = view.substr(sublime.Region(view.line(locations[0]).begin(), locations[0]))
-        match = re.search(r"[,\s]*([A-Z][\w_.#']*|[\w_]+)$", line)
-
-        if match != None:
-            (context,) = match.groups()
-            length = 0# len(context) - len(prefix)
-
-            header = view.substr(sublime.Region(0, 4096))
-            opens  = re.findall(r"^open ([\w.]+)$", header, flags=re.MULTILINE)
-
-            if view.file_name() != None:
-                (module,) = re.search(r"(\w+)\.ml.*$", view.file_name()).groups()
-                opens.append(module.capitalize())
-
-            results = []
-
-            if prefix == "_":
-                results.append(('_', '_'))
-
-            results += self.run_completion(view.window().folders(), opens, context, length)
-
-            if view.buffer_id() in self.local_cache:
-                results += self.local_cache[view.buffer_id()]
-
-            return results, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS
-
-    if int(sublime.version()) < 3014:
-        def on_close(self, view):
-            self.local_cache.pop(view.buffer_id())
-
-        def on_load(self, view):
-            self.extract_locals(view)
-
-        def on_post_save(self, view):
-            self.extract_locals(view)
-
-    else:
-        def on_close_async(self, view):
-            self.local_cache.pop(view.buffer_id())
-
-        def on_load_async(self, view):
-            self.extract_locals(view)
-
-        def on_post_save_async(self, view):
-            self.extract_locals(view)
-
-    def run_completion(self, includes, opens, query, length):
-        args = ['ocp-index', 'complete']
-
-        if localInclude:
-            for include in includes:
-                args.append('-I')
-                args.append(include)
-
-        for open in opens:
-            args.append('-O')
-            args.append(open)
-
-        args.append(query)
-
-        proc = subprocess.Popen(args,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE)
-
-        output   = proc.stdout.read().decode('utf-8').strip()
-        variants = re.sub(r"\n\s+", " ", output).split("\n")
-
-        result = []
-
-        for variant in variants:
-            if variant.count(" ") > 0:
-                (replacement, rest) = str.split(variant, " ", 1)
-                actual_replacement = replacement[length:]
-                result.append((replacement + "\t" + rest, actual_replacement))
-
-        return result
-
-    def extract_locals(self, view):
-        local_defs = []
-        view.find_all(r"let(\s+rec)?\s+(([?~]?[\w']+\s*)+)=", 0, r"\2", local_defs)
-        view.find_all(r"fun\s+(([?~]?[\w']+\s*)+)->", 0, r"\1", local_defs)
-
-        locals = set()
-        for definition in local_defs:
-            for local in str.split(definition):
-                (local,) = re.match(r"^[?~]?(.+)", local).groups()
-                locals.add((local + "\tlet", local))
-
-        self.local_cache[view.buffer_id()] = list(locals)

--- a/sublime_ocp_index.py
+++ b/sublime_ocp_index.py
@@ -4,10 +4,6 @@ import subprocess
 import re
 
 OCPKEY = "OCaml Autocompletion"
-DEFAULT_INCLUDE = True
-
-localInclude = DEFAULT_INCLUDE
-
 
 class SublimeOCPIndex():
     local_cache = dict()
@@ -15,10 +11,11 @@ class SublimeOCPIndex():
     def run_ocp(self, command, includes, opens, query, length, settings):
         args = ['ocp-index', command]
 
-        allowInclude = localInclude
         viewInclude = settings.get('autocomplete-local-ocaml-packages')
         if viewInclude is not None:
             allowInclude = viewInclude
+        else:
+            allowInclude = True
 
         if allowInclude:
             for include in includes:

--- a/sublime_ocp_index.py
+++ b/sublime_ocp_index.py
@@ -11,7 +11,7 @@ class SublimeOCPIndex():
     def run_ocp(self, command, includes, opens, query, length, settings):
         args = ['ocp-index', command]
 
-        viewInclude = settings.get('autocomplete-local-ocaml-packages')
+        viewInclude = settings.get('sublime_ocp_index_include_local_packages')
         if viewInclude is not None:
             allowInclude = viewInclude
         else:
@@ -22,7 +22,7 @@ class SublimeOCPIndex():
                 args.append('-I')
                 args.append(include)
 
-        buildDir = settings.get('ocamlbuild_dir')
+        buildDir = settings.get('sublime_ocp_index_build_dir')
         if buildDir is not None:
             args.append('--build')
             args.append(buildDir)

--- a/sublime_ocp_index.py
+++ b/sublime_ocp_index.py
@@ -36,8 +36,6 @@ class SublimeOCPIndex():
 
         args.append(query)
 
-        print(args)
-
         proc = subprocess.Popen(args,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE)


### PR DESCRIPTION
This wasn't difficult to achieve, the only real change to make the existing code work with `ocp-index type` was that instead of cutting the line off at the cursor, we extend it to the end of the current word using sublime's `view.word()` function.

After that, everything else was refactoring:
- Type checking requires specific build detail that completion just searches for, so I had to make a way to provide the `--build` parameter before it worked in my project.
- A single class can't be used as both a Sublime event listener and command listener, and I didn't want to make everything top-level, so I extracted the logic to a new class.
- The old code was rearranged into query extraction, ocp-index execution, and completion-specific logic. This lets `query_type` be a very simple method. There are probably better ways to achieve this, I'm not a complete python guru :)

I've done command line experiments with `--context` to solve the limitation I mention in the readme, but extracting that information from sublime could be tricky. I want to get your feedback on the bulk of the change before I spend any more time on it :)
