### PR TITLE
Fix for inspecting variables with underscores

### DIFF
--- a/sublime_ocp_index.py
+++ b/sublime_ocp_index.py
@@ -84,6 +84,11 @@ class SublimeOCPIndex():
 
     def query_type(self, view, location):
         endword = view.word(location).end()
+        while view.substr(endword) is '_':
+            endword = endword + 1
+            if view.substr(endword) is not ' ':
+                endword = view.word(endword).end()
+
         query = self.extract_query(view, endword)
 
         if query is not None:
@@ -94,7 +99,7 @@ class SublimeOCPIndex():
             if (result is None or len(result) == 0):
                 return "Unknown type: '%s'" % queryString
             else:
-                return result
+                return "Type: %s" % result
 
 
     def query_completions(self, view, prefix, location):
@@ -182,7 +187,8 @@ class SublimeOcpTypes(sublime_plugin.TextCommand):
 
             result = sublimeocp.query_type(self.view, locations[0])
 
-            self.view.set_status(OCPKEY,"Type: " + result)
+            if result is not None:
+                self.view.set_status(OCPKEY, result)
 
 # ST2 backwards compatibility
 if (int(sublime.version()) < 3000):


### PR DESCRIPTION
In a variable containing underscores, pressing alt+a with the cursor before the last underscore searches for an incomplete variable name due to the way sublime word expansion works. If this continues to be a problem I might look at better ways to find the end of the variable name.

Fix also tweaks the status bar update to not throw an error when the query is None.
