### PR TITLE
Fix moduleName capitalization

### DIFF
--- a/sublime_ocp_index.py
+++ b/sublime_ocp_index.py
@@ -83,7 +83,7 @@ class SublimeOCPIndex():
 
             if view.file_name() != None:
                 (moduleName,) = re.search(r"(\w+)\.ml.*$", view.file_name()).groups()
-                module = moduleName.capitalize()
+                module = moduleName[0].upper() + moduleName[1:]
 
                 (line,col) = view.rowcol(location)
                 context = "%s:%d,%d" % (view.file_name(), line, col)


### PR DESCRIPTION
str.capitalize() lowercases every letter besides the first one, breaking some module names (myModule.ml gives Mymodule instead of MyModule). This change capitalizes only the first letter.
